### PR TITLE
Add build option '-Wa,-mbig-obj' for Linux and Windows configurations

### DIFF
--- a/engine/premake5.lua
+++ b/engine/premake5.lua
@@ -22,7 +22,8 @@ workspace "Zeytin"
         buildoptions {
             "-w",
             "-std=c++17",
-            "-static-libstdc++"
+            "-static-libstdc++",
+            "-Wa,-mbig-obj"
         }
 
     filter { "system:linux", "configurations:EDITOR_MODE" }
@@ -58,7 +59,8 @@ workspace "Zeytin"
             "-std=c++17",
             "-w",
             "-static-libgcc",
-            "-static-libstdc++"
+            "-static-libstdc++",
+            "-Wa,-mbig-obj"
         }
 
     filter { "system:windows", "configurations:STANDALONE" }


### PR DESCRIPTION
gcc on MSYS2 has problems building the engine project. Mainly the issue is that `zeytin.cpp` file is too big. This compile flag fixes that.